### PR TITLE
Fix scan logic and backend integration

### DIFF
--- a/app/Http/Controllers/PredictionController.php
+++ b/app/Http/Controllers/PredictionController.php
@@ -11,9 +11,15 @@ use Illuminate\Http\Response;
 use Symfony\Component\Process\Process;
 use Illuminate\Support\Facades\Log;
 use Illuminate\Support\Facades\Storage;
+use Inertia\Inertia;
 
 class PredictionController extends Controller
 {
+    public function create()
+    {
+        return Inertia::render('Predictions/Create');
+    }
+
     public function store(Request $request)
     {
         try {

--- a/resources/js/components/plant-scanner.tsx
+++ b/resources/js/components/plant-scanner.tsx
@@ -82,7 +82,7 @@ const PlantScanner: React.FC = () => {
     formData.append('image', selectedImage);
 
     try {
-      const response = await axios.post('/api/predict', formData, {
+      const response = await axios.post('/predictions', formData, {
         headers: {
           'Content-Type': 'multipart/form-data',
           'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]')?.getAttribute('content') || '',

--- a/resources/js/pages/Predictions/Create.tsx
+++ b/resources/js/pages/Predictions/Create.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import AppLayout from '@/layouts/app-layout';
+import { Head } from '@inertiajs/react';
+import PlantScanner from '@/components/plant-scanner';
+
+const Create: React.FC = () => {
+  return (
+    <AppLayout>
+      <Head title="New Scan" />
+      
+      <div className="py-6 px-4 sm:px-6 lg:px-8 bg-black min-h-screen">
+        <div className="max-w-4xl mx-auto">
+          <div className="mb-6">
+            <h1 className="text-2xl font-bold text-white">New Plant Scan</h1>
+            <p className="text-gray-400">Upload an image of your plant to detect diseases</p>
+          </div>
+          
+          <PlantScanner />
+        </div>
+      </div>
+    </AppLayout>
+  );
+};
+
+export default Create;

--- a/routes/web.php
+++ b/routes/web.php
@@ -71,6 +71,7 @@ Route::middleware(['auth', 'verified'])->group(function () {
     Route::post('/ai-chat/{chat}/message', [AIChatController::class, 'sendMessage'])->name('ai-chat.message');
     
     // Prediction routes
+    Route::get('/predictions/create', [PredictionController::class, 'create'])->name('predictions.create');
     Route::post('/predictions', [PredictionController::class, 'store'])->name('predictions.store');
 });
 


### PR DESCRIPTION
Implements the "New Scan" page and corrects the scan submission endpoint.

Resolves the 404 error when clicking "New Scan" by adding the missing route and frontend component, and ensures the plant scanner correctly sends data to the backend's `/predictions` endpoint.

---

**Open Background Agent:** 

[Web](https://www.cursor.com/agents?id=bc-dd990652-b125-411c-b139-3a26e88a9d76) · [Cursor](https://cursor.com/background-agent?bcId=bc-dd990652-b125-411c-b139-3a26e88a9d76)

Refer to [Background Agent docs](https://docs.cursor.com/background-agents)